### PR TITLE
ci: upgrade workflows to Node.js 26

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,23 +15,28 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [26.x]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: Show toolchain versions
+        run: |
+          node --version
+          pnpm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 26
+
+      - name: Show Node.js version
+        run: node --version
 
       - name: Get version from package.json
         run: |

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "CoreServe",
   "version": "1.0.1",
   "main": "index.js",
+  "engines": {
+    "node": ">=26"
+  },
   "scripts": {
     "lint": "eslint .",
     "dev": "NODE_ENV=development node index.js",


### PR DESCRIPTION
Upgrades CI and release automation to Node.js 26, updates GitHub Actions to current major versions, and declares Node.js 26+ in package metadata.

Validation target: pnpm install, lint, and Jest tests on Node.js 26.